### PR TITLE
[Fix] Init Regression

### DIFF
--- a/.changeset/itchy-jobs-return.md
+++ b/.changeset/itchy-jobs-return.md
@@ -1,0 +1,5 @@
+---
+'@journeyapps/powersync-sdk-common': patch
+---
+
+Fixed regression where `waitForReady` would not trigger or resolve if not invoked before `init`

--- a/packages/powersync-sdk-react-native/src/db/PowerSyncDatabase.ts
+++ b/packages/powersync-sdk-react-native/src/db/PowerSyncDatabase.ts
@@ -9,7 +9,7 @@ import { ReactNativeRemote } from '../sync/stream/ReactNativeRemote';
 import { ReactNativeStreamingSyncImplementation } from '../sync/stream/ReactNativeStreamingSyncImplementation';
 
 export class PowerSyncDatabase extends AbstractPowerSyncDatabase {
-  async _init(): Promise<void> {}
+  async _initialize(): Promise<void> {}
 
   protected generateBucketStorageAdapter(): BucketStorageAdapter {
     return new SqliteBucketStorage(this.database, AbstractPowerSyncDatabase.transactionMutex);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2066,13 +2066,6 @@
     "@types/yargs" "^17.0.8"
     chalk "^4.0.0"
 
-"@journeyapps/react-native-quick-sqlite@0.1.0":
-  version "0.1.0"
-  resolved "https://registry.npmjs.org/@journeyapps/react-native-quick-sqlite/-/react-native-quick-sqlite-0.1.0.tgz#51f38f04c477cd8f457465aec48d097d7df85011"
-  integrity sha512-uF1R2RGFXhuY1vvjABAR47kuUSATJmf4RWLmTBHtBa8pLkPh/DKqbvCGhO9lsCC8JDzUfY0+xhsCmnQ4t5trow==
-  dependencies:
-    lodash "^4.17.21"
-
 "@journeyapps/react-native-quick-sqlite@0.1.1":
   version "0.1.1"
   resolved "https://registry.npmjs.org/@journeyapps/react-native-quick-sqlite/-/react-native-quick-sqlite-0.1.1.tgz#94145dba13b177f6aa42552754e56ecc3b2e7f17"


### PR DESCRIPTION
# Description
The work from https://github.com/powersync-ja/powersync-react-native-sdk/pull/25 introduced `waitForReady` on the PowerSyncDatabase client. This function should resolve once the client has been fully initialised.

The `waitForReady` method was previously responsible for setting the `AbstractPowerSyncDatabase.ready` member, but the `initialized` listener would only be registered once `waitForReady` had been called. If the `init` function had been called and completed before any `waitForReady` calls were made: the executed `waitForReady` function would never resolve as the `initialized` event would not be triggered again (init was already completed).

This issue was initially not detected in testing as (a logged in) test app contains watched queries which triggered  `waitForReady` and correctly configured the `initialized` listener before `init` had completed. This bug is however relevant when completing the signin flow as no queries are awaited before the `init` call is made. 

## Fix
The API now follows the [Flutter SDK](https://github.com/powersync-ja/powersync.dart/blob/2f5733340bcb3ba08b0a028bc1b3958def8bc632/lib/src/powersync_database.dart#L119) by automatically calling the `initialize` method when the client is constructed. The `init` method now also follows the [FlutterSDK](https://github.com/powersync-ja/powersync.dart/blob/2f5733340bcb3ba08b0a028bc1b3958def8bc632/lib/src/powersync_database.dart#L129) by using `waitForReady` to allow catching any errors during initialisation and await intitialzation, `waitForReady` is still used throughout the implementation as it's name is more indicative of its function. 
