### PR TITLE
[Update] Raw Data

### DIFF
--- a/.changeset/moody-hotels-happen.md
+++ b/.changeset/moody-hotels-happen.md
@@ -1,0 +1,5 @@
+---
+'@journeyapps/powersync-sdk-common': patch
+---
+
+Added `raw-data:true` to PowerSync instance streaming requests. This aides with server and client side OplogEntry processing.

--- a/packages/powersync-sdk-common/src/client/sync/bucket/OplogEntry.ts
+++ b/packages/powersync-sdk-common/src/client/sync/bucket/OplogEntry.ts
@@ -7,7 +7,7 @@ export interface OplogEntryJSON {
   object_type: string;
   object_id: string;
   checksum: number;
-  data: string | object;
+  data: string;
   subkey: string | object;
 }
 
@@ -20,7 +20,7 @@ export class OplogEntry {
       typeof row.subkey == 'string' ? row.subkey : JSON.stringify(row.subkey),
       row.object_type,
       row.object_id,
-      typeof row.data == 'string' ? JSON.parse(row.data) : row.data
+      row.data
     );
   }
 
@@ -31,7 +31,7 @@ export class OplogEntry {
     public subkey: string,
     public object_type?: string,
     public object_id?: string,
-    public data?: Record<string, any>
+    public data?: string
   ) {}
 
   toJSON(): OplogEntryJSON {
@@ -41,7 +41,7 @@ export class OplogEntry {
       object_type: this.object_type,
       object_id: this.object_id,
       checksum: this.checksum,
-      data: JSON.stringify(this.data),
+      data: this.data,
       subkey: JSON.stringify(this.subkey)
     };
   }

--- a/packages/powersync-sdk-common/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
+++ b/packages/powersync-sdk-common/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
@@ -166,7 +166,8 @@ export abstract class AbstractStreamingSyncImplementation extends BaseObserver<S
         for await (let line of this.streamingSyncRequest(
           {
             buckets: req,
-            include_checksum: true
+            include_checksum: true,
+            raw_data: true
           },
           signal
         )) {

--- a/packages/powersync-sdk-common/src/client/sync/stream/streaming-sync-types.ts
+++ b/packages/powersync-sdk-common/src/client/sync/stream/streaming-sync-types.ts
@@ -70,6 +70,11 @@ export interface StreamingSyncRequest {
    * Whether or not to compute a checksum for each checkpoint
    */
   include_checksum: boolean;
+
+  /**
+   * Changes the response to stringified data in each OplogEntry
+   */
+  raw_data: boolean;
 }
 
 export interface StreamingSyncCheckpoint {


### PR DESCRIPTION
This uses the `raw_data` mode when connecting to PowerSync instances. 

The raw data mode assists with better server and client side performance.