### PR TITLE
[Improvement] Better locks and Sync

### DIFF
--- a/.changeset/dull-radios-relate.md
+++ b/.changeset/dull-radios-relate.md
@@ -2,6 +2,7 @@
 '@journeyapps/powersync-sdk-common': major
 ---
 
+- Bump version out of Beta
 - The SyncStatus now includes the state of if the connector is uploading or downloading data.
 - Crud uploads are now debounced.
 - Crud uploads now are also triggered on `execute` method calls.

--- a/.changeset/dull-radios-relate.md
+++ b/.changeset/dull-radios-relate.md
@@ -2,4 +2,8 @@
 '@journeyapps/powersync-sdk-common': patch
 ---
 
-Added better locking for CRUD uploads
+- The SyncStatus now includes the state of if the connector is uploading or downloading data.
+- Crud uploads are now debounced.
+- Crud uploads now are also triggered on `execute` method calls.
+- Database name is now added to the `DBAdapter` interface for better identification in locks (for Web SDK)
+- Failed crud uploads now correctly throw errors, to be caught upstream, and delayed for retry.

--- a/.changeset/dull-radios-relate.md
+++ b/.changeset/dull-radios-relate.md
@@ -1,0 +1,5 @@
+---
+'@journeyapps/powersync-sdk-common': patch
+---
+
+Added better locking for CRUD uploads

--- a/.changeset/dull-radios-relate.md
+++ b/.changeset/dull-radios-relate.md
@@ -1,5 +1,5 @@
 ---
-'@journeyapps/powersync-sdk-common': patch
+'@journeyapps/powersync-sdk-common': major
 ---
 
 - The SyncStatus now includes the state of if the connector is uploading or downloading data.

--- a/.changeset/gold-hairs-repair.md
+++ b/.changeset/gold-hairs-repair.md
@@ -1,0 +1,6 @@
+---
+'@journeyapps/powersync-sdk-react-native': major
+'@journeyapps/powersync-react': major
+---
+
+Release out of beta to production ready

--- a/.changeset/gold-hairs-repair.md
+++ b/.changeset/gold-hairs-repair.md
@@ -1,6 +1,7 @@
 ---
 '@journeyapps/powersync-sdk-react-native': major
 '@journeyapps/powersync-react': major
+'@journeyapps/powersync-attachments': major
 ---
 
 Release out of beta to production ready

--- a/packages/powersync-attachments/README.md
+++ b/packages/powersync-attachments/README.md
@@ -2,8 +2,6 @@
 
 A [PowerSync](https://powersync.co) library to manage attachments in TypeScript and React Native apps.
 
-Note: This package is currently in a beta release.
-
 
 ## Installation
 

--- a/packages/powersync-react/README.md
+++ b/packages/powersync-react/README.md
@@ -1,7 +1,5 @@
 # React components for PowerSync
 
-This package is currently in a beta release.
-
 ## Context
 Configure a PowerSync DB connection and add it to a context provider.
 

--- a/packages/powersync-sdk-common/README.md
+++ b/packages/powersync-sdk-common/README.md
@@ -1,7 +1,3 @@
-# Beta
-This package is currently in a beta release.
-
-
 # PowerSync SDK common JS
 
 This package contains pure TypeScript common functionality for the PowerSync SDK.

--- a/packages/powersync-sdk-common/src/client/AbstractPowerSyncDatabase.ts
+++ b/packages/powersync-sdk-common/src/client/AbstractPowerSyncDatabase.ts
@@ -339,7 +339,9 @@ export abstract class AbstractPowerSyncDatabase extends BaseObserver<PowerSyncDB
    */
   async execute(sql: string, parameters?: any[]) {
     await this.waitForReady();
-    return this.database.execute(sql, parameters);
+    const result = await this.database.execute(sql, parameters);
+    _.defer(() => this.syncStreamImplementation?.triggerCrudUpload());
+    return result;
   }
 
   /**

--- a/packages/powersync-sdk-common/src/client/AbstractPowerSyncOpenFactory.ts
+++ b/packages/powersync-sdk-common/src/client/AbstractPowerSyncOpenFactory.ts
@@ -1,4 +1,4 @@
-import { DBAdapter } from 'src/db/DBAdapter';
+import { DBAdapter } from '../db/DBAdapter';
 import { Schema } from '../db/schema/Schema';
 import { AbstractPowerSyncDatabase, PowerSyncDatabaseOptions } from './AbstractPowerSyncDatabase';
 

--- a/packages/powersync-sdk-common/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
+++ b/packages/powersync-sdk-common/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
@@ -58,7 +58,7 @@ export abstract class AbstractStreamingSyncImplementation extends BaseObserver<S
 
   constructor(options: AbstractStreamingSyncImplementationOptions) {
     super();
-    this.options = _.merge({ ...DEFAULT_STREAMING_SYNC_OPTIONS }, options);
+    this.options = { ...DEFAULT_STREAMING_SYNC_OPTIONS, ...options };
     this.syncStatus = new SyncStatus({
       connected: false,
       lastSyncedAt: null,

--- a/packages/powersync-sdk-common/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
+++ b/packages/powersync-sdk-common/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
@@ -58,7 +58,7 @@ export abstract class AbstractStreamingSyncImplementation extends BaseObserver<S
 
   constructor(options: AbstractStreamingSyncImplementationOptions) {
     super();
-    this.options = _.merge(DEFAULT_STREAMING_SYNC_OPTIONS, options);
+    this.options = _.merge(_.clone(DEFAULT_STREAMING_SYNC_OPTIONS), options);
     this.syncStatus = new SyncStatus({
       connected: false,
       lastSyncedAt: null,

--- a/packages/powersync-sdk-common/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
+++ b/packages/powersync-sdk-common/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
@@ -56,7 +56,7 @@ export abstract class AbstractStreamingSyncImplementation extends BaseObserver<S
 
   constructor(options: AbstractStreamingSyncImplementationOptions) {
     super();
-    this.options = { ...DEFAULT_STREAMING_SYNC_OPTIONS, ...options };
+    this.options = _.merge(DEFAULT_STREAMING_SYNC_OPTIONS, options);
     this.syncStatus = new SyncStatus({
       connected: false,
       lastSyncedAt: null,

--- a/packages/powersync-sdk-common/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
+++ b/packages/powersync-sdk-common/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
@@ -87,7 +87,7 @@ export abstract class AbstractStreamingSyncImplementation extends BaseObserver<S
   }
 
   triggerCrudUpload() {
-    if (this.syncStatus.dataFlowStatus.uploading) {
+    if (!this.syncStatus.connected || this.syncStatus.dataFlowStatus.uploading) {
       return;
     }
     this._uploadAllCrud();
@@ -233,7 +233,10 @@ export abstract class AbstractStreamingSyncImplementation extends BaseObserver<S
               this.logger.debug('validated checkpoint', appliedCheckpoint);
               this.updateSyncStatus({
                 connected: true,
-                lastSyncedAt: new Date()
+                lastSyncedAt: new Date(),
+                dataFlow: {
+                  downloading: false
+                }
               });
             }
 

--- a/packages/powersync-sdk-common/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
+++ b/packages/powersync-sdk-common/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
@@ -64,7 +64,7 @@ export abstract class AbstractStreamingSyncImplementation extends BaseObserver<S
   }
 
   get lastSyncedAt() {
-    return new Date(this._lastSyncedAt);
+    return this._lastSyncedAt && new Date(this._lastSyncedAt);
   }
 
   protected get logger() {

--- a/packages/powersync-sdk-common/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
+++ b/packages/powersync-sdk-common/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
@@ -49,7 +49,7 @@ export const DEFAULT_STREAMING_SYNC_OPTIONS = {
 };
 
 export abstract class AbstractStreamingSyncImplementation extends BaseObserver<StreamingSyncImplementationListener> {
-  protected _lastSyncedAt: Date;
+  protected _lastSyncedAt: Date | null;
   protected options: AbstractStreamingSyncImplementationOptions;
 
   private isUploadingCrud: boolean;
@@ -61,6 +61,7 @@ export abstract class AbstractStreamingSyncImplementation extends BaseObserver<S
     this.options = { ...DEFAULT_STREAMING_SYNC_OPTIONS, ...options };
     this.isUploadingCrud = false;
     this._isConnected = false;
+    this._lastSyncedAt = null;
   }
 
   get lastSyncedAt() {
@@ -305,7 +306,7 @@ export abstract class AbstractStreamingSyncImplementation extends BaseObserver<S
     }
   }
 
-  private updateSyncStatus(connected: boolean, lastSyncedAt?: Date) {
+  protected updateSyncStatus(connected: boolean, lastSyncedAt?: Date) {
     const takeSnapShot = () => [this._isConnected, this._lastSyncedAt?.valueOf()];
 
     const previousValues = takeSnapShot();

--- a/packages/powersync-sdk-common/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
+++ b/packages/powersync-sdk-common/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
@@ -58,7 +58,7 @@ export abstract class AbstractStreamingSyncImplementation extends BaseObserver<S
 
   constructor(options: AbstractStreamingSyncImplementationOptions) {
     super();
-    this.options = _.merge(_.clone(DEFAULT_STREAMING_SYNC_OPTIONS), options);
+    this.options = _.merge({ ...DEFAULT_STREAMING_SYNC_OPTIONS }, options);
     this.syncStatus = new SyncStatus({
       connected: false,
       lastSyncedAt: null,
@@ -152,6 +152,15 @@ export abstract class AbstractStreamingSyncImplementation extends BaseObserver<S
   }
 
   async streamingSync(signal?: AbortSignal): Promise<void> {
+    signal?.addEventListener('abort', () => {
+      this.updateSyncStatus({
+        connected: false,
+        dataFlow: {
+          downloading: false
+        }
+      });
+    });
+
     while (true) {
       try {
         if (signal?.aborted) {

--- a/packages/powersync-sdk-common/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
+++ b/packages/powersync-sdk-common/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
@@ -213,9 +213,13 @@ export abstract class AbstractStreamingSyncImplementation extends BaseObserver<S
           signal
         )) {
           // A connection is active and messages are being received
-          this.updateSyncStatus({
-            connected: true
-          });
+          if (!this.syncStatus.connected) {
+            // There is a connection now
+            _.defer(() => this.triggerCrudUpload());
+            this.updateSyncStatus({
+              connected: true
+            });
+          }
 
           if (isStreamingSyncCheckpoint(line)) {
             targetCheckpoint = line.checkpoint;

--- a/packages/powersync-sdk-common/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
+++ b/packages/powersync-sdk-common/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
@@ -351,7 +351,7 @@ export abstract class AbstractStreamingSyncImplementation extends BaseObserver<S
     const updatedStatus = new SyncStatus({
       connected: options.connected ?? this.syncStatus.connected,
       lastSyncedAt: options.lastSyncedAt ?? this.syncStatus.lastSyncedAt,
-      dataFlow: _.merge(this.syncStatus.dataFlowStatus, options.dataFlow ?? {})
+      dataFlow: _.merge(_.clone(this.syncStatus.dataFlowStatus), options.dataFlow ?? {})
     });
 
     if (!this.syncStatus.isEqual(updatedStatus)) {

--- a/packages/powersync-sdk-common/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
+++ b/packages/powersync-sdk-common/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
@@ -352,6 +352,7 @@ export abstract class AbstractStreamingSyncImplementation extends BaseObserver<S
     });
 
     if (!this.syncStatus.isEqual(updatedStatus)) {
+      this.syncStatus = updatedStatus;
       this.iterateListeners((cb) => cb.statusChanged?.(updatedStatus));
     }
   }

--- a/packages/powersync-sdk-common/src/db/DBAdapter.ts
+++ b/packages/powersync-sdk-common/src/db/DBAdapter.ts
@@ -70,9 +70,10 @@ export interface DBLockOptions {
 
 export interface DBAdapter extends BaseObserverInterface<DBAdapterListener>, DBGetUtils {
   close: () => void;
+  execute: (query: string, params?: any[]) => Promise<QueryResult>;
+  name: string;
   readLock: <T>(fn: (tx: LockContext) => Promise<T>, options?: DBLockOptions) => Promise<T>;
   readTransaction: <T>(fn: (tx: Transaction) => Promise<T>, options?: DBLockOptions) => Promise<T>;
   writeLock: <T>(fn: (tx: LockContext) => Promise<T>, options?: DBLockOptions) => Promise<T>;
   writeTransaction: <T>(fn: (tx: Transaction) => Promise<T>, options?: DBLockOptions) => Promise<T>;
-  execute: (query: string, params?: any[]) => Promise<QueryResult>;
 }

--- a/packages/powersync-sdk-common/src/db/crud/SyncStatus.ts
+++ b/packages/powersync-sdk-common/src/db/crud/SyncStatus.ts
@@ -1,7 +1,42 @@
+import _ from 'lodash';
+
+export type SyncDataFlowStatus = Partial<{
+  downloading: boolean;
+  uploading: boolean;
+}>;
+
+export type SyncStatusOptions = {
+  connected?: boolean;
+  dataFlow?: SyncDataFlowStatus;
+  lastSyncedAt?: Date;
+};
+
 export class SyncStatus {
-  constructor(public connected: boolean, public lastSyncedAt?: Date) {}
+  constructor(protected options: SyncStatusOptions) {}
+
+  get connected() {
+    return this.options.connected ?? false;
+  }
+
+  get lastSyncedAt() {
+    return this.options.lastSyncedAt;
+  }
+
+  get dataFlowStatus() {
+    return (
+      this.options.dataFlow ?? {
+        downloading: false,
+        uploading: false
+      }
+    );
+  }
+
+  isEqual(status: SyncStatus) {
+    return _.isEqual(this.options, status.options);
+  }
 
   getMessage() {
-    return `SyncStatus<connected: ${this.connected} lastSyncedAt: ${this.lastSyncedAt}>`;
+    const { dataFlow } = this.options;
+    return `SyncStatus<connected: ${this.connected} lastSyncedAt: ${this.lastSyncedAt}. Downloading: ${dataFlow.downloading}. Uploading: ${dataFlow.uploading}`;
   }
 }

--- a/packages/powersync-sdk-common/src/db/crud/SyncStatus.ts
+++ b/packages/powersync-sdk-common/src/db/crud/SyncStatus.ts
@@ -1,5 +1,5 @@
 export class SyncStatus {
-  constructor(public connected: boolean, public lastSyncedAt: Date) {}
+  constructor(public connected: boolean, public lastSyncedAt?: Date) {}
 
   getMessage() {
     return `SyncStatus<connected: ${this.connected} lastSyncedAt: ${this.lastSyncedAt}>`;

--- a/packages/powersync-sdk-react-native/README.md
+++ b/packages/powersync-sdk-react-native/README.md
@@ -2,9 +2,6 @@
 
 [PowerSync](https://powersync.co) is a service and set of SDKs that keeps Postgres databases in sync with on-device SQLite databases. See a summary of features [here](https://docs.powersync.co/client-sdk-references/react-native-and-expo).
 
-## Beta Release
-This React Native SDK package is currently in a beta release.
-
 # Installation
 
 ## Install Package

--- a/packages/powersync-sdk-react-native/package.json
+++ b/packages/powersync-sdk-react-native/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://docs.powersync.co/",
   "peerDependencies": {
-    "@journeyapps/react-native-quick-sqlite": "0.1.1",
+    "@journeyapps/react-native-quick-sqlite": "^1.0.0",
     "base-64": "^1.0.0",
     "react": "*",
     "react-native": "*",
@@ -44,7 +44,7 @@
     "async-lock": "^1.4.0"
   },
   "devDependencies": {
-    "@journeyapps/react-native-quick-sqlite": "0.1.1",
+    "@journeyapps/react-native-quick-sqlite": "^1.0.0",
     "@types/async-lock": "^1.4.0",
     "react-native": "0.72.4",
     "react": "18.2.0",

--- a/packages/powersync-sdk-react-native/src/db/adapters/react-native-quick-sqlite/RNQSDBAdapter.ts
+++ b/packages/powersync-sdk-react-native/src/db/adapters/react-native-quick-sqlite/RNQSDBAdapter.ts
@@ -18,7 +18,7 @@ export class RNQSDBAdapter extends BaseObserver<DBAdapterListener> implements DB
   getOptional: <T>(sql: string, parameters?: any[]) => Promise<T | null>;
   get: <T>(sql: string, parameters?: any[]) => Promise<T>;
 
-  constructor(protected baseDB: QuickSQLiteConnection) {
+  constructor(protected baseDB: QuickSQLiteConnection, public name: string) {
     super();
     // link table update commands
     baseDB.registerUpdateHook((update) => {

--- a/packages/powersync-sdk-react-native/src/db/adapters/react-native-quick-sqlite/RNQSDBOpenFactory.ts
+++ b/packages/powersync-sdk-react-native/src/db/adapters/react-native-quick-sqlite/RNQSDBOpenFactory.ts
@@ -34,7 +34,7 @@ export class RNQSPowerSyncDatabaseOpenFactory extends AbstractPowerSyncDatabaseO
       }
     }
 
-    return new RNQSDBAdapter(DB);
+    return new RNQSDBAdapter(DB, this.options.dbFilename);
   }
 
   generateInstance(options: PowerSyncDatabaseOptions): AbstractPowerSyncDatabase {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2074,6 +2074,14 @@
     lodash "^4.17.21"
     uuid "3.4.0"
 
+"@journeyapps/react-native-quick-sqlite@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/@journeyapps/react-native-quick-sqlite/-/react-native-quick-sqlite-1.0.0.tgz#bb836a82a64705a2be6de27560b1e8816bba19d0"
+  integrity sha512-rQPE5OoMfXCyBBnCNMhkd4pES8zt0CbxiWb6GfZ04ik/cKji14GWBkvw9YZdyutc3zb3CNiexHYP1xZzlQYTQg==
+  dependencies:
+    lodash "^4.17.21"
+    uuid "3.4.0"
+
 "@jridgewell/gen-mapping@^0.3.0", "@jridgewell/gen-mapping@^0.3.2":
   version "0.3.3"
   resolved "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz#7e02e6eb5df901aaedb08514203b096614024098"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2066,42 +2066,6 @@
     "@types/yargs" "^17.0.8"
     chalk "^4.0.0"
 
-"@journeyapps/powersync-attachments@0.0.3":
-  version "0.0.3"
-  resolved "https://registry.npmjs.org/@journeyapps/powersync-attachments/-/powersync-attachments-0.0.3.tgz#9c33da5140edafeb5b054ced6a7365869e14633e"
-  integrity sha512-Aq0O7nFRfvxTddxzY4hJ7mWKl2oz/Ube8URZ+EbPo5rjLm3sTV+UKOZ54eS3bBqYjqAgeVUwCSphkWzs00BClQ==
-  dependencies:
-    "@journeyapps/powersync-sdk-common" "0.1.2"
-
-"@journeyapps/powersync-react@0.1.1":
-  version "0.1.1"
-  resolved "https://registry.npmjs.org/@journeyapps/powersync-react/-/powersync-react-0.1.1.tgz#60d12b425a3d16d0f556f89998fb706bc0ba51bf"
-  integrity sha512-bAJDSsyXjE8dbLqGVaKp7UOD09T3piKS1/uYl1j0i/nZjLb1PV5IfBDrO7nzMUj9v38TpT3gW8FitcnnMMCkxw==
-  dependencies:
-    "@journeyapps/powersync-sdk-common" "0.1.2"
-
-"@journeyapps/powersync-sdk-common@0.1.2":
-  version "0.1.2"
-  resolved "https://registry.npmjs.org/@journeyapps/powersync-sdk-common/-/powersync-sdk-common-0.1.2.tgz#309bdb049d2939f05a06d20ab526de39a8539895"
-  integrity sha512-lQExqszNY7bK8HYlNDDsO2mtK2yb3mRAQPVOSMsgo1ssQmxMP9RGdII+HvPkEIprcEkmNogS8AhY6QN/U7wq8w==
-  dependencies:
-    async-mutex "^0.4.0"
-    can-ndjson-stream "^1.0.2"
-    event-iterator "^2.0.0"
-    js-logger "^1.6.1"
-    lodash "^4.17.21"
-    object-hash "^3.0.0"
-    uuid "^3.0.0"
-
-"@journeyapps/powersync-sdk-react-native@0.1.2":
-  version "0.1.2"
-  resolved "https://registry.npmjs.org/@journeyapps/powersync-sdk-react-native/-/powersync-sdk-react-native-0.1.2.tgz#8f44e37e9bf5397228c0ca8c09770c6919795ea8"
-  integrity sha512-SA3qdRQOizcYyOzeGPaH838Kr+jSmEU+GcOo8Ze9u6gsY6zazwQyyCUJGqOgyMqnOTXGoX7HGNXXacVenLbLkA==
-  dependencies:
-    "@journeyapps/powersync-react" "0.1.1"
-    "@journeyapps/powersync-sdk-common" "0.1.2"
-    async-lock "^1.4.0"
-
 "@journeyapps/react-native-quick-sqlite@0.1.1":
   version "0.1.1"
   resolved "https://registry.npmjs.org/@journeyapps/react-native-quick-sqlite/-/react-native-quick-sqlite-0.1.1.tgz#94145dba13b177f6aa42552754e56ecc3b2e7f17"


### PR DESCRIPTION
# Description

This PR introduces some improvements for the sync locking and status flows. This PR also adds changesets to release out of Beta to v1.0.0

## Sync Status
The SyncStatus now includes the state of if the connector is uploading or downloading data.

## Sync Flow
Crud uploads are now debounced.
Crud uploads now are also triggered on `execute` methods.
Database name is now added to the `DBAdapter` interface for better identification in locks (for Web SDK)
Failed crud uploads now correctly throw errors, to be caught upstream, and delayed for retry.