### PR TITLE
[Fix] Issues with localFileURI on iOS Simulator

### DIFF
--- a/.changeset/polite-grapes-cover.md
+++ b/.changeset/polite-grapes-cover.md
@@ -2,4 +2,4 @@
 '@journeyapps/powersync-attachments': patch
 ---
 
-Change `AbstractAttachmentQueue` implementation to not save the full URI in the `attachments` table, instead create the full URI when needed.
+Change `AbstractAttachmentQueue` implementation to not save the full URI in the `attachments` table, instead create it when needed.

--- a/.changeset/polite-grapes-cover.md
+++ b/.changeset/polite-grapes-cover.md
@@ -1,0 +1,5 @@
+---
+'@journeyapps/powersync-attachments': patch
+---
+
+Change `AbstractAttachmentQueue` implementation to not save the full URI in the `attachments` table, instead create the full URI when needed.

--- a/packages/powersync-attachments/README.md
+++ b/packages/powersync-attachments/README.md
@@ -160,9 +160,9 @@ export class AttachmentQueue extends AbstractAttachmentQueue {
     const photoAttachment = await this.newAttachmentRecord();
     photoAttachment.local_uri = this.getLocalFilePathSuffix(photoAttachment.filename);
     
-    const localFilePathURI = this.getLocalUri(photoAttachment.local_uri);
+    const localFilePathUri = this.getLocalUri(photoAttachment.local_uri);
     
-    await this.storage.writeFile(localFilePathURI, base64Data, { encoding: 'base64' });
+    await this.storage.writeFile(localFilePathUri, base64Data, { encoding: 'base64' });
 
     return this.saveToQueue(photoAttachment);
   }

--- a/packages/powersync-attachments/README.md
+++ b/packages/powersync-attachments/README.md
@@ -158,8 +158,11 @@ export class AttachmentQueue extends AbstractAttachmentQueue {
   // ...
   async savePhoto(base64Data) {
     const photoAttachment = await this.newAttachmentRecord();
-    photoAttachment.local_uri = this.getLocalUri(photoAttachment.filename);
-    await this.storage.writeFile(photoAttachment.local_uri, base64Data, { encoding: 'base64' });
+    photoAttachment.local_uri = this.getLocalFilePathSuffix(photoAttachment.filename);
+    
+    const localFilePathURI = this.getLocalUri(photoAttachment.local_uri);
+    
+    await this.storage.writeFile(localFilePathURI, base64Data, { encoding: 'base64' });
 
     return this.saveToQueue(photoAttachment);
   }

--- a/packages/powersync-attachments/src/AbstractAttachmentQueue.ts
+++ b/packages/powersync-attachments/src/AbstractAttachmentQueue.ts
@@ -76,10 +76,6 @@ export abstract class AbstractAttachmentQueue<T extends AttachmentQueueOptions =
     return ATTACHMENT_TABLE;
   }
 
-  get storageDirectory() {
-    return `${this.storage.getUserStorageDirectory()}${this.options.attachmentDirectoryName}`;
-  }
-
   async init() {
     // Ensure the directory where attachments are downloaded, exists
     await this.storage.makeDir(this.storageDirectory);
@@ -134,7 +130,7 @@ export abstract class AbstractAttachmentQueue<T extends AttachmentQueueOptions =
           });
           console.debug(`Attachment (${id}) not found in database, creating new record`);
           await this.saveToQueue(newRecord);
-        } else if (record.local_uri == null || !(await this.storage.fileExists(record.local_uri))) {
+        } else if (record.local_uri == null || !(await this.storage.fileExists(this.getLocalUri(record.local_uri)))) {
           // 2. Attachment in database but no local file, mark as queued download
           console.debug(`Attachment (${id}) found in database but no local file, marking as queued download`);
           await this.update({
@@ -211,11 +207,11 @@ export abstract class AbstractAttachmentQueue<T extends AttachmentQueueOptions =
       await this.powersync.writeTransaction(deleteRecord);
     }
 
-    const uri = record.local_uri || this.getLocalUri(record.filename);
+    const localFilePathURI = this.getLocalUri(record.local_uri || this.getLocalFilePathSuffix(record.filename));
 
     try {
       // Delete file on storage
-      await this.storage.deleteFile(uri, {
+      await this.storage.deleteFile(localFilePathURI, {
         filename: record.filename
       });
     } catch (e) {
@@ -241,8 +237,10 @@ export abstract class AbstractAttachmentQueue<T extends AttachmentQueueOptions =
     if (!record.local_uri) {
       throw new Error(`No local_uri for record ${JSON.stringify(record, null, 2)}`);
     }
+
+    const localFilePathURI = this.getLocalUri(record.local_uri);
     try {
-      if (!(await this.storage.fileExists(record.local_uri))) {
+      if (!(await this.storage.fileExists(localFilePathURI))) {
         console.warn(`File for ${record.id} does not exist, skipping upload`);
         await this.update({
           ...record,
@@ -251,7 +249,7 @@ export abstract class AbstractAttachmentQueue<T extends AttachmentQueueOptions =
         return true;
       }
 
-      const fileBuffer = await this.storage.readFile(record.local_uri, {
+      const fileBuffer = await this.storage.readFile(localFilePathURI, {
         encoding: EncodingType.Base64,
         mediaType: record.media_type
       });
@@ -276,9 +274,10 @@ export abstract class AbstractAttachmentQueue<T extends AttachmentQueueOptions =
 
   async downloadRecord(record: AttachmentRecord) {
     if (!record.local_uri) {
-      record.local_uri = this.getLocalUri(record.filename);
+      record.local_uri = this.getLocalFilePathSuffix(record.filename);
     }
-    if (await this.storage.fileExists(record.local_uri)) {
+    const localFilePathURI = this.getLocalUri(record.local_uri);
+    if (await this.storage.fileExists(localFilePathURI)) {
       console.debug(`Local file already downloaded, marking "${record.id}" as synced`);
       await this.update({ ...record, state: AttachmentState.SYNCED });
       return true;
@@ -299,9 +298,9 @@ export abstract class AbstractAttachmentQueue<T extends AttachmentQueueOptions =
       });
 
       // Ensure directory exists
-      await this.storage.makeDir(record.local_uri.replace(record.filename, ''));
+      await this.storage.makeDir(localFilePathURI.replace(record.filename, ''));
       // Write the file
-      await this.storage.writeFile(record.local_uri, base64Data, {
+      await this.storage.writeFile(localFilePathURI, base64Data, {
         encoding: EncodingType.Base64
       });
 
@@ -436,8 +435,28 @@ export abstract class AbstractAttachmentQueue<T extends AttachmentQueueOptions =
     }
   }
 
-  getLocalUri(filename: string): string {
-    return `${this.storageDirectory}/${filename}`;
+  /**
+   * Returns the local file path for the given filename, used to store in the database.
+   * Example: filename: "attachment-1.jpg" returns "attachments/attachment-1.jpg"
+   */
+  getLocalFilePathSuffix(filename: string): string {
+    return `${this.options.attachmentDirectoryName}/${filename}`;
+  }
+
+  /**
+   * Return users storage directory with the attachmentPath use to load the file.
+   * Example: filePath: "attachments/attachment-1.jpg" returns "/var/mobile/Containers/Data/Application/.../Library/attachments/attachment-1.jpg"
+   */
+  getLocalUri(filePath: string): string {
+    return `${this.storage.getUserStorageDirectory()}/${filePath}`;
+  }
+
+  /**
+   * Returns the directory where attachments are stored on the device, used to make dir
+   * Example: "/var/mobile/Containers/Data/Application/.../Library/attachments/"
+   */
+  get storageDirectory() {
+    return `${this.storage.getUserStorageDirectory()}${this.options.attachmentDirectoryName}`;
   }
 
   async expireCache() {

--- a/packages/powersync-attachments/src/AbstractAttachmentQueue.ts
+++ b/packages/powersync-attachments/src/AbstractAttachmentQueue.ts
@@ -207,11 +207,11 @@ export abstract class AbstractAttachmentQueue<T extends AttachmentQueueOptions =
       await this.powersync.writeTransaction(deleteRecord);
     }
 
-    const localFilePathURI = this.getLocalUri(record.local_uri || this.getLocalFilePathSuffix(record.filename));
+    const localFilePathUri = this.getLocalUri(record.local_uri || this.getLocalFilePathSuffix(record.filename));
 
     try {
       // Delete file on storage
-      await this.storage.deleteFile(localFilePathURI, {
+      await this.storage.deleteFile(localFilePathUri, {
         filename: record.filename
       });
     } catch (e) {
@@ -238,9 +238,9 @@ export abstract class AbstractAttachmentQueue<T extends AttachmentQueueOptions =
       throw new Error(`No local_uri for record ${JSON.stringify(record, null, 2)}`);
     }
 
-    const localFilePathURI = this.getLocalUri(record.local_uri);
+    const localFilePathUri = this.getLocalUri(record.local_uri);
     try {
-      if (!(await this.storage.fileExists(localFilePathURI))) {
+      if (!(await this.storage.fileExists(localFilePathUri))) {
         console.warn(`File for ${record.id} does not exist, skipping upload`);
         await this.update({
           ...record,
@@ -249,7 +249,7 @@ export abstract class AbstractAttachmentQueue<T extends AttachmentQueueOptions =
         return true;
       }
 
-      const fileBuffer = await this.storage.readFile(localFilePathURI, {
+      const fileBuffer = await this.storage.readFile(localFilePathUri, {
         encoding: EncodingType.Base64,
         mediaType: record.media_type
       });
@@ -276,8 +276,8 @@ export abstract class AbstractAttachmentQueue<T extends AttachmentQueueOptions =
     if (!record.local_uri) {
       record.local_uri = this.getLocalFilePathSuffix(record.filename);
     }
-    const localFilePathURI = this.getLocalUri(record.local_uri);
-    if (await this.storage.fileExists(localFilePathURI)) {
+    const localFilePathUri = this.getLocalUri(record.local_uri);
+    if (await this.storage.fileExists(localFilePathUri)) {
       console.debug(`Local file already downloaded, marking "${record.id}" as synced`);
       await this.update({ ...record, state: AttachmentState.SYNCED });
       return true;
@@ -298,9 +298,9 @@ export abstract class AbstractAttachmentQueue<T extends AttachmentQueueOptions =
       });
 
       // Ensure directory exists
-      await this.storage.makeDir(localFilePathURI.replace(record.filename, ''));
+      await this.storage.makeDir(localFilePathUri.replace(record.filename, ''));
       // Write the file
-      await this.storage.writeFile(localFilePathURI, base64Data, {
+      await this.storage.writeFile(localFilePathUri, base64Data, {
         encoding: EncodingType.Base64
       });
 

--- a/packages/powersync-attachments/src/StorageAdapter.ts
+++ b/packages/powersync-attachments/src/StorageAdapter.ts
@@ -1,31 +1,20 @@
 export enum EncodingType {
-  UTF8 = "utf8",
-  Base64 = "base64",
+  UTF8 = 'utf8',
+  Base64 = 'base64'
 }
 
 export interface StorageAdapter {
-  uploadFile(
-    filePath: string,
-    data: ArrayBuffer,
-    options?: { mediaType?: string }
-  ): Promise<void>;
+  uploadFile(filePath: string, data: ArrayBuffer, options?: { mediaType?: string }): Promise<void>;
 
   downloadFile(filePath: string): Promise<Blob>;
 
-  writeFile(
-    fileURI: string,
-    base64Data: string,
-    options?: { encoding?: EncodingType }
-  ): Promise<void>;
+  writeFile(fileUri: string, base64Data: string, options?: { encoding?: EncodingType }): Promise<void>;
 
-  readFile(
-    fileURI: string,
-    options?: { encoding?: EncodingType; mediaType?: string }
-  ): Promise<ArrayBuffer>;
+  readFile(fileUri: string, options?: { encoding?: EncodingType; mediaType?: string }): Promise<ArrayBuffer>;
 
   deleteFile(uri: string, options?: { filename?: string }): Promise<void>;
 
-  fileExists(fileURI: string): Promise<boolean>;
+  fileExists(fileUri: string): Promise<boolean>;
 
   makeDir(uri: string): Promise<void>;
 


### PR DESCRIPTION
## Description

Change `AbstractAttachmentQueue` implementation to not save the full URI in the `attachments` table, instead create it when needed.

### Issue with iOS Simulator
When running the app in iOS Simulator, the reference to local storage is a directory generated for each debug device and would cause an error to be thrown, when the app tries to read the file. 

Example:
`
Error: File 'file:///Users/myuser/Library/Developer/CoreSimulator/Devices/060C2A66-D025-4C79-A77A-BE20DB439D0F/data/Containers/Data/Application/BEDD6677-78EF-4198-8655-9CDA98B71BB1/Documents/attachments/7b0630be-963d-49c4-af8e-52dc817b5c95.jpg' isn't readable.
`

### Adds
- `getLocalFilePathSuffix()` to only append a `filename` to the attachment directory name
- Change `getLocalUri` to take a `filePath` instead of a `filename`

### Tested

Tested on iOS simulator <-> Android physical device

## Note
Possibly breaking change if your app relies on `queue.getLocalUri(filename)`, this will now need to change to `queue.getLocalUri( queue.getLocalFilePathSuffix(filename) )`