### PR TITLE
[Fix] Watched query updates

### DIFF
--- a/.changeset/angry-foxes-hammer.md
+++ b/.changeset/angry-foxes-hammer.md
@@ -1,0 +1,5 @@
+---
+'@journeyapps/powersync-sdk-react-native': patch
+---
+
+Fixed watched queries from updating before writes have been commited on the write connection.

--- a/.changeset/fast-chicken-vanish.md
+++ b/.changeset/fast-chicken-vanish.md
@@ -1,0 +1,6 @@
+---
+'@journeyapps/powersync-sdk-react-native': minor
+'@journeyapps/powersync-sdk-common': minor
+---
+
+Added the ability to receive batched table updates from DB adapters.

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "apps/supabase-todolist"]
 	path = apps/supabase-todolist
-	url = git@github.com:journeyapps/powersync-supabase-react-native-todolist-demo.git
+	url = git@github.com:powersync-ja/powersync-supabase-react-native-todolist-demo.git

--- a/packages/powersync-sdk-common/src/client/AbstractPowerSyncDatabase.ts
+++ b/packages/powersync-sdk-common/src/client/AbstractPowerSyncDatabase.ts
@@ -1,13 +1,7 @@
 import _ from 'lodash';
 import { Mutex } from 'async-mutex';
 import Logger, { ILogger } from 'js-logger';
-import {
-  BatchedUpdateNotification,
-  DBAdapter,
-  QueryResult,
-  Transaction,
-  isBatchedUpdateNotification
-} from '../db/DBAdapter';
+import { DBAdapter, QueryResult, Transaction, isBatchedUpdateNotification } from '../db/DBAdapter';
 import { Schema } from '../db/schema/Schema';
 import { SyncStatus } from '../db/crud/SyncStatus';
 import { UploadQueueStats } from '../db/crud/UploadQueueStatus';

--- a/packages/powersync-sdk-common/src/client/AbstractPowerSyncDatabase.ts
+++ b/packages/powersync-sdk-common/src/client/AbstractPowerSyncDatabase.ts
@@ -1,7 +1,13 @@
 import _ from 'lodash';
 import { Mutex } from 'async-mutex';
 import Logger, { ILogger } from 'js-logger';
-import { DBAdapter, QueryResult, Transaction } from '../db/DBAdapter';
+import {
+  BatchedUpdateNotification,
+  DBAdapter,
+  QueryResult,
+  Transaction,
+  isBatchedUpdateNotification
+} from '../db/DBAdapter';
 import { Schema } from '../db/schema/Schema';
 import { SyncStatus } from '../db/crud/SyncStatus';
 import { UploadQueueStats } from '../db/crud/UploadQueueStatus';
@@ -511,15 +517,21 @@ export abstract class AbstractPowerSyncDatabase extends BaseObserver<PowerSyncDB
 
       const dispose = this.database.registerListener({
         tablesUpdated: async (update) => {
-          const { table } = update;
           const { rawTableNames } = options;
 
-          if (!rawTableNames && !table.match(POWERSYNC_TABLE_MATCH)) {
+          const tables = isBatchedUpdateNotification(update) ? update.tables : [update.table];
+
+          const filteredTables = rawTableNames ? tables : tables.filter((t) => !!t.match(POWERSYNC_TABLE_MATCH));
+          if (!filteredTables.length) {
             return;
           }
 
-          const tableName = rawTableNames ? table : table.replace(POWERSYNC_TABLE_MATCH, '');
-          throttledTableUpdates.push(tableName);
+          // Remove any PowerSync table prefixes if necessary
+          const mappedTableNames = rawTableNames
+            ? filteredTables
+            : filteredTables.map((t) => t.replace(POWERSYNC_TABLE_MATCH, ''));
+
+          throttledTableUpdates.push(...mappedTableNames);
 
           flushTableUpdates();
         }

--- a/packages/powersync-sdk-react-native/package.json
+++ b/packages/powersync-sdk-react-native/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://docs.powersync.co/",
   "peerDependencies": {
-    "@journeyapps/react-native-quick-sqlite": "^1.0.0",
+    "@journeyapps/react-native-quick-sqlite": "^1.1.0",
     "base-64": "^1.0.0",
     "react": "*",
     "react-native": "*",
@@ -44,7 +44,7 @@
     "async-lock": "^1.4.0"
   },
   "devDependencies": {
-    "@journeyapps/react-native-quick-sqlite": "0.0.0-dev-20240123100027",
+    "@journeyapps/react-native-quick-sqlite": "^1.1.0",
     "@types/async-lock": "^1.4.0",
     "react-native": "0.72.4",
     "react": "18.2.0",

--- a/packages/powersync-sdk-react-native/package.json
+++ b/packages/powersync-sdk-react-native/package.json
@@ -44,7 +44,7 @@
     "async-lock": "^1.4.0"
   },
   "devDependencies": {
-    "@journeyapps/react-native-quick-sqlite": "^1.0.0",
+    "@journeyapps/react-native-quick-sqlite": "0.0.0-dev-20240123100027",
     "@types/async-lock": "^1.4.0",
     "react-native": "0.72.4",
     "react": "18.2.0",

--- a/packages/powersync-sdk-react-native/src/db/adapters/react-native-quick-sqlite/RNQSDBAdapter.ts
+++ b/packages/powersync-sdk-react-native/src/db/adapters/react-native-quick-sqlite/RNQSDBAdapter.ts
@@ -21,7 +21,7 @@ export class RNQSDBAdapter extends BaseObserver<DBAdapterListener> implements DB
   constructor(protected baseDB: QuickSQLiteConnection, public name: string) {
     super();
     // link table update commands
-    baseDB.registerUpdateHook((update) => {
+    baseDB.registerTablesChangedHook((update) => {
       this.iterateListeners((cb) => cb.tablesUpdated?.(update));
     });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2220,10 +2220,10 @@
     "@types/yargs" "^17.0.8"
     chalk "^4.0.0"
 
-"@journeyapps/react-native-quick-sqlite@0.0.0-dev-20240123100027":
-  version "0.0.0-dev-20240123100027"
-  resolved "https://registry.npmjs.org/@journeyapps/react-native-quick-sqlite/-/react-native-quick-sqlite-0.0.0-dev-20240123100027.tgz#f91c305326012cefaf53508875017dd6ba6f530d"
-  integrity sha512-hT0axuG/2Y8YeiXVlPeXCNm+tfSBDhJS1ffT9x0dCHuzh4YWZnCOmwA6SVnj3dARFaWvKz3er2hklGgS1H1n3g==
+"@journeyapps/react-native-quick-sqlite@^1.0.0", "@journeyapps/react-native-quick-sqlite@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/@journeyapps/react-native-quick-sqlite/-/react-native-quick-sqlite-1.1.0.tgz#cf4aa6694b7232d0f86e565fdba4e41ef15d80cc"
+  integrity sha512-Pg6VA6ABC7N5FrNB5eqTgNsKdzzmDSp5aBtnQh1BlcZu7ISPZdCcKo+ZJtKyzTAWpc17LIttvJwxez6zBxUdOw==
   dependencies:
     lodash "^4.17.21"
     uuid "3.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2220,10 +2220,10 @@
     "@types/yargs" "^17.0.8"
     chalk "^4.0.0"
 
-"@journeyapps/react-native-quick-sqlite@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/@journeyapps/react-native-quick-sqlite/-/react-native-quick-sqlite-1.0.0.tgz#bb836a82a64705a2be6de27560b1e8816bba19d0"
-  integrity sha512-rQPE5OoMfXCyBBnCNMhkd4pES8zt0CbxiWb6GfZ04ik/cKji14GWBkvw9YZdyutc3zb3CNiexHYP1xZzlQYTQg==
+"@journeyapps/react-native-quick-sqlite@0.0.0-dev-20240123100027":
+  version "0.0.0-dev-20240123100027"
+  resolved "https://registry.npmjs.org/@journeyapps/react-native-quick-sqlite/-/react-native-quick-sqlite-0.0.0-dev-20240123100027.tgz#f91c305326012cefaf53508875017dd6ba6f530d"
+  integrity sha512-hT0axuG/2Y8YeiXVlPeXCNm+tfSBDhJS1ffT9x0dCHuzh4YWZnCOmwA6SVnj3dARFaWvKz3er2hklGgS1H1n3g==
   dependencies:
     lodash "^4.17.21"
     uuid "3.4.0"


### PR DESCRIPTION
# Description 
This PR fixes a bug where watched queries would sometimes fail to reflect updates from `writeTransaction`s.

Watched queries don't update due to a race condition where the table change hook is fired before the changes have been committed. The read connections re-execute watched queries, but don't return the latest updates. 

This builds off the work from https://github.com/powersync-ja/react-native-quick-sqlite/pull/13 which adds new methods for receiving table change updates once changes have been committed to the DB.

The common `DBAdapter` interface has been updated in order to be compatible with the previous DB connection API for single table updates and the recently updated Batch updates. 

# Testing:
This was tested using the React Native Todolist app. 

## Before
With the current SDK certain operations only reflect in watched queries when refreshed. Initially Item `3` was deleted, but still remains on the view until a new item is created. There is also a large delay between creating the item and it appearing on screen. This is caused by the initial table update not firing at the correct time, the query is refreshed once the sync bucket is refreshed (due to syncing).

https://github.com/powersync-ja/powersync-react-native-sdk/assets/51082125/5c8104da-242c-488c-9447-9dcbc8748dd8


## After
With the new updates all operations are reflected in the watched query in a timely manner.

https://github.com/powersync-ja/powersync-react-native-sdk/assets/51082125/15316829-962a-472f-8e9f-8fcb0c14e0fd



TODO:
- [x] Update dev packages