### PR TITLE
[Feature] Table View Overrides

### DIFF
--- a/.changeset/curly-peas-argue.md
+++ b/.changeset/curly-peas-argue.md
@@ -1,0 +1,5 @@
+---
+'@journeyapps/powersync-sdk-common': patch
+---
+
+Added `viewName` option to Schema Table definitions. This allows for overriding a table's view name.

--- a/.changeset/warm-foxes-act.md
+++ b/.changeset/warm-foxes-act.md
@@ -2,4 +2,4 @@
 '@journeyapps/powersync-sdk-common': patch
 ---
 
-Fixed table change updates to be throttled and flushed on the trailing edge to avoid race conditions in watched queries.
+Improved table change updates to be throttled on the trailing edge. This prevents unnecessary query on both the leading and rising edge. 

--- a/.changeset/warm-foxes-act.md
+++ b/.changeset/warm-foxes-act.md
@@ -1,0 +1,5 @@
+---
+'@journeyapps/powersync-sdk-common': patch
+---
+
+Fixed table change updates to be throttled and flushed on the trailing edge to avoid race conditions in watched queries.

--- a/.changeset/yellow-kangaroos-allow.md
+++ b/.changeset/yellow-kangaroos-allow.md
@@ -1,0 +1,5 @@
+---
+'@journeyapps/powersync-sdk-react-native': patch
+---
+
+Bumped powrsync-sqlite-core to v0.1.5. Depdendent projects should run `pod repo update && pod update` in the `ios` folder for updates to reflect.

--- a/packages/powersync-sdk-common/src/client/AbstractPowerSyncDatabase.ts
+++ b/packages/powersync-sdk-common/src/client/AbstractPowerSyncDatabase.ts
@@ -158,6 +158,7 @@ export abstract class AbstractPowerSyncDatabase extends BaseObserver<PowerSyncDB
     await this.bucketStorageAdapter.init();
     const version = await this.options.database.execute('SELECT powersync_rs_version()');
     this.sdkVersion = version.rows?.item(0)['powersync_rs_version()'] ?? '';
+    await this.updateSchema(this.options.schema);
     this.ready = true;
     this.iterateListeners((cb) => cb.initialized?.());
   }

--- a/packages/powersync-sdk-common/src/client/AbstractPowerSyncDatabase.ts
+++ b/packages/powersync-sdk-common/src/client/AbstractPowerSyncDatabase.ts
@@ -499,15 +499,19 @@ export abstract class AbstractPowerSyncDatabase extends BaseObserver<PowerSyncDB
     const throttleMs = options.throttleMs ?? DEFAULT_WATCH_THROTTLE_MS;
 
     return new EventIterator<WatchOnChangeEvent>((eventOptions) => {
-      const flushTableUpdates = _.throttle(async () => {
-        const intersection = _.intersection(watchedTables, throttledTableUpdates);
-        if (intersection.length) {
-          eventOptions.push({
-            changedTables: intersection
-          });
-        }
-        throttledTableUpdates = [];
-      }, throttleMs);
+      const flushTableUpdates = _.throttle(
+        async () => {
+          const intersection = _.intersection(watchedTables, throttledTableUpdates);
+          if (intersection.length) {
+            eventOptions.push({
+              changedTables: intersection
+            });
+          }
+          throttledTableUpdates = [];
+        },
+        throttleMs,
+        { leading: false, trailing: true }
+      );
 
       const dispose = this.database.registerListener({
         tablesUpdated: async (update) => {

--- a/packages/powersync-sdk-common/src/client/AbstractPowerSyncDatabase.ts
+++ b/packages/powersync-sdk-common/src/client/AbstractPowerSyncDatabase.ts
@@ -18,7 +18,6 @@ import { CrudEntry } from './sync/bucket/CrudEntry';
 import { mutexRunExclusive } from '../utils/mutex';
 import { BaseObserver } from '../utils/BaseObserver';
 import { EventIterator } from 'event-iterator';
-import { AssertionError } from 'assert';
 import { quoteIdentifier } from '../utils/strings';
 
 export interface DisconnectAndClearOptions {
@@ -165,7 +164,7 @@ export abstract class AbstractPowerSyncDatabase extends BaseObserver<PowerSyncDB
 
   async updateSchema(schema: Schema) {
     if (this.abortController) {
-      throw new AssertionError({ message: 'Cannot update schema while connected' });
+      throw new Error('Cannot update schema while connected');
     }
 
     schema.validate();

--- a/packages/powersync-sdk-common/src/client/AbstractPowerSyncDatabase.ts
+++ b/packages/powersync-sdk-common/src/client/AbstractPowerSyncDatabase.ts
@@ -19,7 +19,7 @@ import { mutexRunExclusive } from '../utils/mutex';
 import { BaseObserver } from '../utils/BaseObserver';
 import { EventIterator } from 'event-iterator';
 import { AssertionError } from 'assert';
-import { quoteIdentifier } from 'src/utils/strings';
+import { quoteIdentifier } from '../utils/strings';
 
 export interface DisconnectAndClearOptions {
   clearLocal?: boolean;

--- a/packages/powersync-sdk-common/src/db/schema/Schema.ts
+++ b/packages/powersync-sdk-common/src/db/schema/Schema.ts
@@ -3,6 +3,12 @@ import type { Table } from './Table';
 export class Schema {
   constructor(public tables: Table[]) {}
 
+  validate() {
+    for (const table of this.tables) {
+      table.validate();
+    }
+  }
+
   toJSON() {
     return {
       tables: this.tables.map((t) => t.toJSON())

--- a/packages/powersync-sdk-common/src/db/schema/Schema.ts
+++ b/packages/powersync-sdk-common/src/db/schema/Schema.ts
@@ -10,6 +10,7 @@ export class Schema {
   }
 
   toJSON() {
+    this.validate();
     return {
       tables: this.tables.map((t) => t.toJSON())
     };

--- a/packages/powersync-sdk-common/src/db/schema/Table.ts
+++ b/packages/powersync-sdk-common/src/db/schema/Table.ts
@@ -90,15 +90,16 @@ export class Table {
 
     const columnNames = new Set<string>();
     columnNames.add('id');
-    for (const column in this.columns) {
-      if (column == 'id') {
+    for (const column of this.columns) {
+      const { name: columnName } = column;
+      if (column.name == 'id') {
         throw new Error(`${this.name}: id column is automatically added, custom id columns are not supported`);
-      } else if (columnNames.has(column)) {
-        throw new Error(`Duplicate column ${column}`);
-      } else if (InvalidSQLCharacters.test(column)) {
+      } else if (columnNames.has(columnName)) {
+        throw new Error(`Duplicate column ${columnName}`);
+      } else if (InvalidSQLCharacters.test(columnName)) {
         throw new Error(`Invalid characters in column name: $name.${column}`);
       }
-      columnNames.add(column);
+      columnNames.add(columnName);
     }
 
     const indexNames = new Set<string>();
@@ -112,7 +113,7 @@ export class Table {
 
       for (const column of index.columns) {
         if (!columnNames.has(column.name)) {
-          throw new Error(`Column $name.${column.name} not found for index ${index.name}`);
+          throw new Error(`Column ${column.name} not found for index ${index.name}`);
         }
       }
 

--- a/packages/powersync-sdk-common/src/db/schema/Table.ts
+++ b/packages/powersync-sdk-common/src/db/schema/Table.ts
@@ -1,12 +1,18 @@
+import _ from 'lodash';
 import { Column } from '../Column';
 import type { Index } from './Index';
+import { AssertionError } from 'assert';
 
 export interface TableOptions {
+  /**
+   * The synced table name, matching sync rules
+   */
   name: string;
   columns: Column[];
   indexes?: Index[];
   localOnly?: boolean;
   insertOnly?: boolean;
+  viewName?: string;
 }
 
 export const DEFAULT_TABLE_OPTIONS: Partial<TableOptions> = {
@@ -14,6 +20,8 @@ export const DEFAULT_TABLE_OPTIONS: Partial<TableOptions> = {
   insertOnly: false,
   localOnly: false
 };
+
+export const InvalidSQLCharacters = /[\"\'%,\.#\s\[\]]/;
 
 export class Table {
   protected options: TableOptions;
@@ -32,6 +40,14 @@ export class Table {
 
   get name() {
     return this.options.name;
+  }
+
+  get viewNameOverride() {
+    return this.options.viewName;
+  }
+
+  get viewName() {
+    return this.viewNameOverride || this.name;
   }
 
   get columns() {
@@ -59,13 +75,65 @@ export class Table {
   }
 
   get validName() {
-    // TODO verify
-    return !/[\"\'%,\.#\s\[\]]/.test(this.name);
+    return _.chain([this.name, this.viewNameOverride])
+      .compact()
+      .every((name) => !InvalidSQLCharacters.test(name))
+      .value();
+  }
+
+  validate() {
+    if (InvalidSQLCharacters.test(this.name)) {
+      throw new AssertionError({ message: `Invalid characters in table name: ${this.name}` });
+    } else if (this.viewNameOverride && InvalidSQLCharacters.test(this.viewNameOverride!)) {
+      throw new AssertionError({
+        message: `
+          Invalid characters in view name: ${this.viewNameOverride}`
+      });
+    }
+
+    const columnNames = new Set<string>();
+    columnNames.add('id');
+    for (const column in this.columns) {
+      if (column == 'id') {
+        throw new AssertionError({
+          message: `${this.name}: id column is automatically added, custom id columns are not supported`
+        });
+      } else if (columnNames.has(column)) {
+        throw new AssertionError({ message: `Duplicate column ${column}` });
+      } else if (InvalidSQLCharacters.test(column)) {
+        throw new AssertionError({ message: `Invalid characters in column name: $name.${column}` });
+      }
+      columnNames.add(column);
+    }
+
+    const indexNames = new Set<string>();
+
+    for (const index of this.indexes) {
+      if (indexNames.has(index.name)) {
+        throw new AssertionError({ message: `Duplicate index $name.${index}` });
+      } else if (InvalidSQLCharacters.test(index.name)) {
+        throw new AssertionError({
+          message: `
+            Invalid characters in index name: $name.${index}`
+        });
+      }
+
+      for (const column of index.columns) {
+        if (!columnNames.has(column.name)) {
+          throw new AssertionError({
+            message: `Column $name.${column.name} not found for index ${index.name}`
+          });
+        }
+      }
+
+      indexNames.add(index.name);
+    }
   }
 
   toJSON() {
     return {
       name: this.name,
+      viewName: this.viewName,
       local_only: this.localOnly,
       insert_only: this.insertOnly,
       columns: this.columns.map((c) => c.toJSON()),

--- a/packages/powersync-sdk-common/src/db/schema/Table.ts
+++ b/packages/powersync-sdk-common/src/db/schema/Table.ts
@@ -133,7 +133,7 @@ export class Table {
   toJSON() {
     return {
       name: this.name,
-      viewName: this.viewName,
+      view_name: this.viewName,
       local_only: this.localOnly,
       insert_only: this.insertOnly,
       columns: this.columns.map((c) => c.toJSON()),

--- a/packages/powersync-sdk-common/src/db/schema/Table.ts
+++ b/packages/powersync-sdk-common/src/db/schema/Table.ts
@@ -1,7 +1,6 @@
 import _ from 'lodash';
 import { Column } from '../Column';
 import type { Index } from './Index';
-import { AssertionError } from 'assert';
 
 export interface TableOptions {
   /**
@@ -83,25 +82,21 @@ export class Table {
 
   validate() {
     if (InvalidSQLCharacters.test(this.name)) {
-      throw new AssertionError({ message: `Invalid characters in table name: ${this.name}` });
+      throw new Error(`Invalid characters in table name: ${this.name}`);
     } else if (this.viewNameOverride && InvalidSQLCharacters.test(this.viewNameOverride!)) {
-      throw new AssertionError({
-        message: `
-          Invalid characters in view name: ${this.viewNameOverride}`
-      });
+      throw new Error(`
+          Invalid characters in view name: ${this.viewNameOverride}`);
     }
 
     const columnNames = new Set<string>();
     columnNames.add('id');
     for (const column in this.columns) {
       if (column == 'id') {
-        throw new AssertionError({
-          message: `${this.name}: id column is automatically added, custom id columns are not supported`
-        });
+        throw new Error(`${this.name}: id column is automatically added, custom id columns are not supported`);
       } else if (columnNames.has(column)) {
-        throw new AssertionError({ message: `Duplicate column ${column}` });
+        throw new Error(`Duplicate column ${column}`);
       } else if (InvalidSQLCharacters.test(column)) {
-        throw new AssertionError({ message: `Invalid characters in column name: $name.${column}` });
+        throw new Error(`Invalid characters in column name: $name.${column}`);
       }
       columnNames.add(column);
     }
@@ -110,19 +105,14 @@ export class Table {
 
     for (const index of this.indexes) {
       if (indexNames.has(index.name)) {
-        throw new AssertionError({ message: `Duplicate index $name.${index}` });
+        throw new Error(`Duplicate index $name.${index}`);
       } else if (InvalidSQLCharacters.test(index.name)) {
-        throw new AssertionError({
-          message: `
-            Invalid characters in index name: $name.${index}`
-        });
+        throw new Error(`Invalid characters in index name: $name.${index}`);
       }
 
       for (const column of index.columns) {
         if (!columnNames.has(column.name)) {
-          throw new AssertionError({
-            message: `Column $name.${column.name} not found for index ${index.name}`
-          });
+          throw new Error(`Column $name.${column.name} not found for index ${index.name}`);
         }
       }
 

--- a/packages/powersync-sdk-common/src/utils/strings.ts
+++ b/packages/powersync-sdk-common/src/utils/strings.ts
@@ -5,3 +5,7 @@ export function quoteString(s: string) {
 export function quoteJsonPath(path: string) {
   return quoteString(`$.${path}`);
 }
+
+export function quoteIdentifier(s: string) {
+  return `"${s.replaceAll('"', '""')}"`;
+}

--- a/packages/powersync-sdk-react-native/package.json
+++ b/packages/powersync-sdk-react-native/package.json
@@ -44,7 +44,7 @@
     "async-lock": "^1.4.0"
   },
   "devDependencies": {
-    "@journeyapps/react-native-quick-sqlite": "^1.1.0",
+    "@journeyapps/react-native-quick-sqlite": "0.0.0-dev-20240130102422",
     "@types/async-lock": "^1.4.0",
     "react-native": "0.72.4",
     "react": "18.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2228,14 +2228,6 @@
     lodash "^4.17.21"
     uuid "3.4.0"
 
-"@journeyapps/react-native-quick-sqlite@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.npmjs.org/@journeyapps/react-native-quick-sqlite/-/react-native-quick-sqlite-1.1.0.tgz#cf4aa6694b7232d0f86e565fdba4e41ef15d80cc"
-  integrity sha512-Pg6VA6ABC7N5FrNB5eqTgNsKdzzmDSp5aBtnQh1BlcZu7ISPZdCcKo+ZJtKyzTAWpc17LIttvJwxez6zBxUdOw==
-  dependencies:
-    lodash "^4.17.21"
-    uuid "3.4.0"
-
 "@jridgewell/gen-mapping@^0.3.0", "@jridgewell/gen-mapping@^0.3.2":
   version "0.3.3"
   resolved "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz#7e02e6eb5df901aaedb08514203b096614024098"
@@ -3611,7 +3603,7 @@ ajv-keywords@^5.1.0:
   dependencies:
     fast-deep-equal "^3.1.3"
 
-ajv@^8.0.0, ajv@^8.9.0:
+ajv@^8.0.0, ajv@^8.11.0, ajv@^8.9.0:
   version "8.12.0"
   resolved "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz#d1a0527323e22f53562c567c00991577dfbe19d1"
   integrity sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==
@@ -5373,6 +5365,14 @@ expo-asset@~8.10.1:
     md5-file "^3.2.3"
     path-browserify "^1.0.0"
     url-parse "^1.5.9"
+
+expo-build-properties@~0.8.3:
+  version "0.8.3"
+  resolved "https://registry.npmjs.org/expo-build-properties/-/expo-build-properties-0.8.3.tgz#fbfa156e9619bebda71c66af9a26ebc3490b2365"
+  integrity sha512-kEDDuAadHqJTkvCGK4fXYHVrePiJO1DjyW95AicmwuGwQvGJydYFbuoauf9ybAU+4UH4arhbce8gHI3ZpIj3Jw==
+  dependencies:
+    ajv "^8.11.0"
+    semver "^7.5.3"
 
 expo-camera@~13.4.4:
   version "13.4.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2220,6 +2220,14 @@
     "@types/yargs" "^17.0.8"
     chalk "^4.0.0"
 
+"@journeyapps/react-native-quick-sqlite@0.0.0-dev-20240130102422":
+  version "0.0.0-dev-20240130102422"
+  resolved "https://registry.npmjs.org/@journeyapps/react-native-quick-sqlite/-/react-native-quick-sqlite-0.0.0-dev-20240130102422.tgz#00f599008f99c12f7c425345819b87bf58b445e6"
+  integrity sha512-iwkEQdTHdZZw4BcoyRmv6O3iSconCgv/868zNVK1/Z87UbxEew1WKNDkuigUJsl70kI+C8AkrAfjmP6cKDKX5w==
+  dependencies:
+    lodash "^4.17.21"
+    uuid "3.4.0"
+
 "@journeyapps/react-native-quick-sqlite@^1.1.0":
   version "1.1.0"
   resolved "https://registry.npmjs.org/@journeyapps/react-native-quick-sqlite/-/react-native-quick-sqlite-1.1.0.tgz#cf4aa6694b7232d0f86e565fdba4e41ef15d80cc"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2220,7 +2220,7 @@
     "@types/yargs" "^17.0.8"
     chalk "^4.0.0"
 
-"@journeyapps/react-native-quick-sqlite@^1.0.0", "@journeyapps/react-native-quick-sqlite@^1.1.0":
+"@journeyapps/react-native-quick-sqlite@^1.1.0":
   version "1.1.0"
   resolved "https://registry.npmjs.org/@journeyapps/react-native-quick-sqlite/-/react-native-quick-sqlite-1.1.0.tgz#cf4aa6694b7232d0f86e565fdba4e41ef15d80cc"
   integrity sha512-Pg6VA6ABC7N5FrNB5eqTgNsKdzzmDSp5aBtnQh1BlcZu7ISPZdCcKo+ZJtKyzTAWpc17LIttvJwxez6zBxUdOw==


### PR DESCRIPTION
This backports updates from the powersync.dart:
1. https://github.com/powersync-ja/powersync.dart/pull/20 - Allow overriding view names by adding a `view_name` field in the table json.
2. https://github.com/powersync-ja/powersync.dart/pull/39


React Native Quick SQLite is updated to include `v1.5.0` changes from `powersync-sqlite-core` https://github.com/powersync-ja/react-native-quick-sqlite/pull/16  https://github.com/powersync-ja/powersync-sqlite-core/pull/3